### PR TITLE
Switch to a Content class

### DIFF
--- a/lib/decant.rb
+++ b/lib/decant.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 require_relative 'decant/collection'
-require_relative 'decant/content_methods'
-require_relative 'decant/file'
+require_relative 'decant/content'
 require_relative 'decant/version'
 
 module Decant
   def self.define(dir:, ext: nil, &block)
-    Class.new(File) do
-      include ContentMethods
+    Class.new(Content) do
       @collection = Collection.new(dir: dir, ext: ext)
       class_eval(&block) if block_given?
     end

--- a/lib/decant/content.rb
+++ b/lib/decant/content.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 require_relative 'errors'
+require_relative 'file'
 
 module Decant
-  module ContentMethods
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
-
-    module ClassMethods
+  class Content < File
+    class << self
       attr_reader :collection
 
       def all

--- a/spec/decant/content_spec.rb
+++ b/spec/decant/content_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Decant::ContentMethods do
+RSpec.describe Decant::Content do
   describe '.all' do
     let(:klass) { Decant.define(dir: tmpdir, ext: ext) }
 

--- a/spec/decant_spec.rb
+++ b/spec/decant_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Decant do
   describe '.define' do
-    it 'sets up a new File subclass with an associated Collection and exposes the class body to the block' do
+    it 'sets up a new Content subclass with an associated Collection and exposes the class body to the block' do
       content = <<~CONTENT
         ---
         title: Welcome


### PR DESCRIPTION
Having a proper Content class makes it easier to talk about and to reference methods even if it's still defined via Decant.define.